### PR TITLE
Fixing Retry test name.

### DIFF
--- a/ch04/retry_test.go
+++ b/ch04/retry_test.go
@@ -20,7 +20,7 @@ func EmulateTransientError(ctx context.Context) (string, error) {
 	}
 }
 
-func RetryTest(t *testing.T) {
+func TestRetry(t *testing.T) {
 	ctx := context.Background()
 	r := Retry(EmulateTransientError, 5, 2*time.Second)
 	res, err := r(ctx)


### PR DESCRIPTION
This should allow for easier use of the test via an IDE like PyCharm.